### PR TITLE
Add Krakow recommendations page

### DIFF
--- a/assets/css/krakow-styles.css
+++ b/assets/css/krakow-styles.css
@@ -1,0 +1,428 @@
+/* Krakow recommendations page */
+
+.krakow-page {
+  width: 100%;
+  max-width: var(--max-content-width);
+  margin: 20px auto 0;
+  padding: 20px;
+}
+
+.krakow-page--cards {
+  max-width: 960px;
+}
+
+.krakow-subtitle {
+  font-size: 0.95rem;
+  color: var(--secondary-color);
+  margin: 0 0 1.5rem;
+}
+
+/* Controls bar */
+.krakow-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.krakow-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.2rem 0.4rem;
+  align-items: center;
+}
+
+.krakow-right-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-shrink: 0;
+}
+
+.krakow-filter,
+.krakow-view,
+.krakow-kids-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-family);
+  font-size: 0.82rem;
+  font-weight: 400;
+  color: var(--secondary-color);
+  text-decoration: none;
+  padding: 0.15rem 0;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.krakow-filter:hover,
+.krakow-view:hover,
+.krakow-kids-toggle:hover {
+  color: var(--primary-color);
+}
+
+.krakow-filter.active,
+.krakow-view.active {
+  color: var(--accent-color);
+  font-weight: 700;
+}
+
+.krakow-kids-toggle.active {
+  color: var(--accent-color);
+  font-weight: 700;
+}
+
+.krakow-controls-sep {
+  color: var(--border-color);
+  font-size: 0.82rem;
+  user-select: none;
+}
+
+/* Tags */
+.krakow-tag {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  border: 1px solid;
+  border-radius: 0;
+  text-transform: uppercase;
+  font-weight: 700;
+  white-space: nowrap;
+  background: transparent;
+  letter-spacing: 0.03em;
+  border-color: var(--accent-color);
+  color: var(--accent-color);
+}
+
+.krakow-tag-kid {
+  font-size: 0.65rem;
+  padding: 0.1rem 0.3rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0;
+  text-transform: uppercase;
+  font-weight: 700;
+  white-space: nowrap;
+  background: transparent;
+  letter-spacing: 0.03em;
+  color: var(--secondary-color);
+}
+
+/* List view */
+.krakow-list {
+  margin: 0;
+}
+
+.krakow-entry {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.krakow-entry:last-child {
+  border-bottom: none;
+}
+
+.krakow-entry.hidden {
+  display: none;
+}
+
+.krakow-entry-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.krakow-entry-title {
+  font-weight: bold;
+  font-size: 1rem;
+}
+
+.krakow-entry-tagline {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--secondary-color);
+}
+
+.krakow-entry-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+  margin-left: 1rem;
+}
+
+/* Card view */
+.krakow-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.krakow-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-color);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s;
+}
+
+.krakow-card:hover {
+  border-color: var(--accent-color);
+  color: inherit;
+}
+
+.krakow-card.hidden {
+  display: none;
+}
+
+.krakow-card-photo {
+  width: 100%;
+  height: 180px;
+  overflow: hidden;
+}
+
+.krakow-card-photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* Placeholder photo when no image provided */
+.krakow-card-photo--placeholder {
+  width: 100%;
+  height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--background-color);
+  background-color: var(--secondary-color);
+}
+
+.krakow-card-photo--placeholder[data-cat="food"] {
+  background-color: #c45d3e;
+}
+
+.krakow-card-photo--placeholder[data-cat="museum"] {
+  background-color: var(--accent-color);
+}
+
+.krakow-card-photo--placeholder[data-cat="nature"] {
+  background-color: #3a7d44;
+}
+
+.krakow-card-photo--placeholder[data-cat="coffee"] {
+  background-color: #8b6f47;
+}
+
+.krakow-card-photo--placeholder[data-cat="bars"] {
+  background-color: #6b4c8a;
+}
+
+.krakow-card-photo--placeholder[data-cat="shops"] {
+  background-color: #555;
+}
+
+html[data-theme="dark"] .krakow-card-photo--placeholder[data-cat="food"] {
+  background-color: #a04030;
+}
+
+html[data-theme="dark"] .krakow-card-photo--placeholder[data-cat="museum"] {
+  background-color: var(--accent-color);
+}
+
+html[data-theme="dark"] .krakow-card-photo--placeholder[data-cat="nature"] {
+  background-color: #2d6435;
+}
+
+html[data-theme="dark"] .krakow-card-photo--placeholder[data-cat="coffee"] {
+  background-color: #6e5838;
+}
+
+html[data-theme="dark"] .krakow-card-photo--placeholder[data-cat="bars"] {
+  background-color: #553d6e;
+}
+
+html[data-theme="dark"] .krakow-card-photo--placeholder[data-cat="shops"] {
+  background-color: #444;
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme="light"]) .krakow-card-photo--placeholder[data-cat="food"] {
+    background-color: #a04030;
+  }
+  html:not([data-theme="light"]) .krakow-card-photo--placeholder[data-cat="museum"] {
+    background-color: var(--accent-color);
+  }
+  html:not([data-theme="light"]) .krakow-card-photo--placeholder[data-cat="nature"] {
+    background-color: #2d6435;
+  }
+  html:not([data-theme="light"]) .krakow-card-photo--placeholder[data-cat="coffee"] {
+    background-color: #6e5838;
+  }
+  html:not([data-theme="light"]) .krakow-card-photo--placeholder[data-cat="bars"] {
+    background-color: #553d6e;
+  }
+  html:not([data-theme="light"]) .krakow-card-photo--placeholder[data-cat="shops"] {
+    background-color: #444;
+  }
+}
+
+.krakow-card-body {
+  padding: 0.8rem;
+  flex: 1;
+}
+
+.krakow-card-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin: 0.4rem 0 0.2rem;
+  color: var(--primary-color);
+}
+
+.krakow-card-tagline {
+  font-size: 0.82rem;
+  color: var(--secondary-color);
+  margin: 0;
+  line-height: 1.4;
+}
+
+/* Empty state */
+.krakow-empty {
+  display: none;
+  padding: 2rem 0;
+  color: var(--secondary-color);
+  font-size: 0.9rem;
+}
+
+.krakow-empty.visible {
+  display: block;
+}
+
+/* Detail page */
+.krakow-single .back-link {
+  margin: 0 0 1.5rem;
+}
+
+.krakow-single .back-link:last-child {
+  margin: 2rem 0 0;
+}
+
+.krakow-single .back-link a {
+  color: var(--secondary-color);
+}
+
+.krakow-detail-meta {
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.krakow-address {
+  font-size: 0.85rem;
+  color: var(--secondary-color);
+}
+
+.krakow-address a {
+  color: var(--link-color);
+}
+
+.krakow-detail-photo {
+  margin-bottom: 1.5rem;
+}
+
+.krakow-detail-photo img {
+  width: 100%;
+  max-height: 400px;
+  object-fit: cover;
+  border: 1px solid var(--border-color);
+}
+
+.krakow-detail-photo--placeholder {
+  width: 100%;
+  height: 250px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--background-color);
+  background-color: var(--secondary-color);
+  margin-bottom: 1.5rem;
+}
+
+.krakow-detail-links {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.85rem;
+}
+
+.krakow-detail-content {
+  margin-top: 1rem;
+}
+
+.krakow-detail-content p {
+  line-height: 1.6;
+}
+
+.krakow-detail-tagline {
+  font-size: 1rem;
+  color: var(--secondary-color);
+  margin-bottom: 1.5rem;
+  font-style: italic;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .krakow-cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .krakow-page {
+    padding: 12px;
+  }
+
+  .krakow-controls {
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  .krakow-right-controls {
+    align-self: flex-end;
+  }
+
+  .krakow-entry {
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+
+  .krakow-entry-meta {
+    margin-left: 0;
+  }
+
+  .krakow-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .krakow-card-photo,
+  .krakow-card-photo--placeholder {
+    height: 160px;
+  }
+}

--- a/content/krakow/_index.md
+++ b/content/krakow/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Krakow"
+draft: false
+---

--- a/content/krakow/recs/_index.md
+++ b/content/krakow/recs/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Krakow"
+description: "A local's guide to Krakow - places I'd send friends to."
+draft: false
+---

--- a/content/krakow/recs/botanic-garden-of-the-jagiellonian-university.md
+++ b/content/krakow/recs/botanic-garden-of-the-jagiellonian-university.md
@@ -1,0 +1,10 @@
+---
+title: "Botanic Garden of the Jagiellonian University"
+date: 2026-04-07
+params:
+  category: "nature"
+  address: ""
+  map_url: "https://goo.gl/maps/bxUhAmKqGdDoGwyP6"
+  tagline: "Beautiful old botanical garden tucked behind the university."
+  kid_friendly: true
+---

--- a/content/krakow/recs/charlotte-chleb-i-wino.md
+++ b/content/krakow/recs/charlotte-chleb-i-wino.md
@@ -1,0 +1,11 @@
+---
+title: "Charlotte - chleb i wino"
+date: 2026-04-07
+params:
+  category: "food"
+  address: ""
+  map_url: "https://goo.gl/maps/cdFhUYkJj7n97afj7"
+  tagline: "French-inspired bakery with excellent bread, breakfast, and wine."
+  url: "https://bistrocharlotte.com/en/locations/cracow/#nasz-lokal"
+  tags: "Bread, Breakfast, French, Wine"
+---

--- a/content/krakow/recs/cogiteon.md
+++ b/content/krakow/recs/cogiteon.md
@@ -1,0 +1,11 @@
+---
+title: "Cogiteon"
+date: 2026-04-07
+params:
+  category: "museum"
+  address: ""
+  map_url: ""
+  tagline: "Interactive science center. Big enough to easily spend half a day."
+  url: "https://cogiteon.pl"
+  kid_friendly: true
+---

--- a/content/krakow/recs/eszeweria.md
+++ b/content/krakow/recs/eszeweria.md
@@ -1,0 +1,9 @@
+---
+title: "Eszeweria"
+date: 2026-04-07
+params:
+  category: "food"
+  address: ""
+  map_url: "https://www.google.com/maps/place/Eszeweria/..."
+  tagline: "Eclectic bar-restaurant in Kazimierz with a garden courtyard."
+---

--- a/content/krakow/recs/fitagain-coffee-and-food.md
+++ b/content/krakow/recs/fitagain-coffee-and-food.md
@@ -1,0 +1,10 @@
+---
+title: "Fitagain Coffee & Food"
+date: 2026-04-07
+params:
+  category: "food"
+  address: ""
+  map_url: "https://g.page/fitagaincafe?share"
+  tagline: "Solid coffee and healthy-ish eats in a relaxed setting."
+  url: "https://www.fitagain.pl/"
+---

--- a/content/krakow/recs/forum-przestrzenie.md
+++ b/content/krakow/recs/forum-przestrzenie.md
@@ -1,0 +1,10 @@
+---
+title: "Forum Przestrzenie"
+date: 2026-04-07
+params:
+  category: "food"
+  address: ""
+  map_url: "https://goo.gl/maps/FX8e2ixQShAUEPZq8"
+  tagline: "Buzzy riverside bar and cultural space in a brutalist former hotel."
+  url: "https://www.forumprzestrzenie.com/"
+---

--- a/content/krakow/recs/good-lood.md
+++ b/content/krakow/recs/good-lood.md
@@ -1,0 +1,10 @@
+---
+title: "Good Lood"
+date: 2026-04-07
+params:
+  category: "food"
+  address: ""
+  map_url: ""
+  tagline: "Krakow's favorite ice cream chain. Worth the queue."
+  url: "https://goodlood.com/en/"
+---

--- a/content/krakow/recs/krakow-pinball-museum.md
+++ b/content/krakow/recs/krakow-pinball-museum.md
@@ -1,0 +1,10 @@
+---
+title: "Krakow Pinball Museum"
+date: 2026-04-07
+params:
+  category: "museum"
+  address: ""
+  map_url: "https://goo.gl/maps/eD65aXA2WaGCbhX29"
+  tagline: "50+ pinball tables and retro arcade games. Seriously fun."
+  kid_friendly: true
+---

--- a/content/krakow/recs/manggha-centre.md
+++ b/content/krakow/recs/manggha-centre.md
@@ -1,0 +1,9 @@
+---
+title: "Manggha Centre"
+date: 2026-04-07
+params:
+  category: "museum"
+  address: ""
+  map_url: "https://www.google.com/maps/place/Manggha+Centre/..."
+  tagline: "Japanese art and technology museum on the Vistula riverbank."
+---

--- a/content/krakow/recs/mocak.md
+++ b/content/krakow/recs/mocak.md
@@ -1,0 +1,9 @@
+---
+title: "MOCAK"
+date: 2026-04-07
+params:
+  category: "museum"
+  address: ""
+  map_url: "https://www.google.com/maps/place/Museum+of+Contemporary+Art+in+Krakow+MOCAK/..."
+  tagline: "Krakow's museum of contemporary art."
+---

--- a/content/krakow/recs/mufo-rakowicka.md
+++ b/content/krakow/recs/mufo-rakowicka.md
@@ -1,0 +1,9 @@
+---
+title: "MuFo Rakowicka"
+date: 2026-04-07
+params:
+  category: "museum"
+  address: ""
+  map_url: "https://www.google.com/maps/place/Muzeum+Fotografii+w+Krakowie+-+MuFo+Rakowicka/..."
+  tagline: "Photography museum with rotating exhibitions worth checking."
+---

--- a/content/krakow/recs/muzeum-gier-wideo.md
+++ b/content/krakow/recs/muzeum-gier-wideo.md
@@ -1,0 +1,10 @@
+---
+title: "Muzeum Gier Wideo"
+date: 2026-04-07
+params:
+  category: "museum"
+  address: ""
+  map_url: "https://goo.gl/maps/Ww2SvFmHpPspAveQ6"
+  tagline: "Retro video game museum. Playable exhibits from every era."
+  kid_friendly: true
+---

--- a/content/krakow/recs/muzeum-iluzji-krakow.md
+++ b/content/krakow/recs/muzeum-iluzji-krakow.md
@@ -1,0 +1,10 @@
+---
+title: "Muzeum Iluzji Krakow"
+date: 2026-04-07
+params:
+  category: "museum"
+  address: ""
+  map_url: "https://goo.gl/maps/kdTvHTwetKJkwZ8u7"
+  tagline: "Optical illusions and interactive tricks. Fun photo ops."
+  kid_friendly: true
+---

--- a/content/krakow/recs/muzeum-inzynierii-i-techniki.md
+++ b/content/krakow/recs/muzeum-inzynierii-i-techniki.md
@@ -1,0 +1,9 @@
+---
+title: "Muzeum Inzynierii i Techniki"
+date: 2026-04-07
+params:
+  category: "museum"
+  address: ""
+  map_url: "https://www.google.com/maps/place/Muzeum+Inzynierii+i+Techniki/..."
+  tagline: "Polish engineering heritage. Great street food square nearby - get the Belgian fries."
+---

--- a/content/krakow/recs/national-museum-in-krakow.md
+++ b/content/krakow/recs/national-museum-in-krakow.md
@@ -1,0 +1,9 @@
+---
+title: "National Museum in Krakow"
+date: 2026-04-07
+params:
+  category: "museum"
+  address: ""
+  map_url: "https://www.google.com/maps/place/National+Museum+in+Krakow/..."
+  tagline: "The big one. Polish art from medieval to modern."
+---

--- a/content/krakow/recs/nic-kawiarnio-ksiegarnia.md
+++ b/content/krakow/recs/nic-kawiarnio-ksiegarnia.md
@@ -1,0 +1,9 @@
+---
+title: "NIC. Kawiarnio-ksiegarnia"
+date: 2026-04-07
+params:
+  category: "coffee"
+  address: ""
+  map_url: "https://maps.app.goo.gl/kUuXyd9kFX7fTy5f7"
+  tagline: "Ukrainian cafe-bookshop."
+---

--- a/content/krakow/recs/nolio.md
+++ b/content/krakow/recs/nolio.md
@@ -1,0 +1,10 @@
+---
+title: "NOLIO"
+date: 2026-04-07
+params:
+  category: "food"
+  address: ""
+  map_url: ""
+  tagline: "Reliable Italian spot with fresh pasta and good vibes."
+  url: "https://nolio.pl/"
+---

--- a/content/krakow/recs/park-jordana.md
+++ b/content/krakow/recs/park-jordana.md
@@ -1,0 +1,10 @@
+---
+title: "Park Jordana"
+date: 2026-04-07
+params:
+  category: "nature"
+  address: ""
+  map_url: "https://maps.apple.com/place?address=Park%20Jordana,%2030-055%20Krak%C3%B3w,%20Poland&coordinate=50.062849,19.915942&name=Park%20Jordana&place-id=I305EDBC4FFE2DC97&map=explore"
+  tagline: "Great park for a walk when the weather cooperates."
+  kid_friendly: true
+---

--- a/content/krakow/recs/polish-aviation-museum.md
+++ b/content/krakow/recs/polish-aviation-museum.md
@@ -1,0 +1,10 @@
+---
+title: "Polish Aviation Museum"
+date: 2026-04-07
+params:
+  category: "museum"
+  address: ""
+  map_url: "https://www.google.com/maps/place/Polish+Aviation+Museum/..."
+  tagline: "380+ aircraft, helicopters, and gliders. Kids love this one."
+  kid_friendly: true
+---

--- a/content/krakow/recs/restauracja-kantyna-zablocie.md
+++ b/content/krakow/recs/restauracja-kantyna-zablocie.md
@@ -1,0 +1,10 @@
+---
+title: "Restauracja Kantyna Zablocie"
+date: 2026-04-07
+params:
+  category: "food"
+  address: ""
+  map_url: "https://g.page/KantynaZablocie?share"
+  tagline: "Hearty Polish cooking in the Zablocie district."
+  url: "https://www.kantynazablocie.pl/galeria/"
+---

--- a/content/krakow/recs/stanislaw-lems-garden-of-experiments.md
+++ b/content/krakow/recs/stanislaw-lems-garden-of-experiments.md
@@ -1,0 +1,10 @@
+---
+title: "Stanislaw Lem's Garden of Experiments"
+date: 2026-04-07
+params:
+  category: "nature"
+  address: ""
+  map_url: "https://goo.gl/maps/2tngR7oJAojAtmRu7"
+  tagline: "Outdoor science playground inspired by the great sci-fi writer."
+  kid_friendly: true
+---

--- a/content/krakow/recs/the-archaeological-museum-in-krakow.md
+++ b/content/krakow/recs/the-archaeological-museum-in-krakow.md
@@ -1,0 +1,9 @@
+---
+title: "The Archaeological Museum in Krakow"
+date: 2026-04-07
+params:
+  category: "museum"
+  address: ""
+  map_url: "https://goo.gl/maps/QVZfviUoSCmruA1A7"
+  tagline: "Ancient artifacts from southern Poland and beyond. Quiet and underrated."
+---

--- a/content/krakow/recs/wesola-cafe.md
+++ b/content/krakow/recs/wesola-cafe.md
@@ -1,0 +1,11 @@
+---
+title: "Wesola Cafe"
+date: 2026-04-07
+params:
+  category: "food"
+  address: ""
+  map_url: "https://goo.gl/maps/6e3jfpjrL8nD7S5h8"
+  tagline: "Cozy breakfast spot with great coffee and comfort food classics."
+  url: "https://wesolacafe.pl/en/"
+  tags: "Breakfast, Coffee, Comfort food"
+---

--- a/content/krakow/recs/yomiko-sushi.md
+++ b/content/krakow/recs/yomiko-sushi.md
@@ -1,0 +1,10 @@
+---
+title: "Yomiko Sushi"
+date: 2026-04-07
+params:
+  category: "food"
+  address: ""
+  map_url: ""
+  tagline: "Clean, well-executed sushi in Krakow."
+  url: "https://www.youmikosushi.pl/"
+---

--- a/content/krakow/recs/zazie-bistro.md
+++ b/content/krakow/recs/zazie-bistro.md
@@ -1,0 +1,10 @@
+---
+title: "Zazie Bistro"
+date: 2026-04-07
+params:
+  category: "food"
+  address: ""
+  map_url: ""
+  tagline: "French bistro cooking done right."
+  url: "http://www.zaziebistro.pl/"
+---

--- a/content/krakow/recs/zielonym-do-gory.md
+++ b/content/krakow/recs/zielonym-do-gory.md
@@ -1,0 +1,10 @@
+---
+title: "Zielonym Do Gory"
+date: 2026-04-07
+params:
+  category: "food"
+  address: ""
+  map_url: ""
+  tagline: "Plant-forward restaurant with a thoughtful seasonal menu."
+  url: "https://www.lwowska1.pl/pl/restauracja-zielonym-do-gory/"
+---

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -13,12 +13,14 @@
     {{ $reading := resources.Get "css/reading-styles.css" | fingerprint }}
     {{ $chat := resources.Get "css/chat-styles.css" | fingerprint }}
     {{ $chatPage := resources.Get "css/chat-page-styles.css" | fingerprint }}
+    {{ $krakow := resources.Get "css/krakow-styles.css" | fingerprint }}
     <link rel="stylesheet" href="{{ $styles.RelPermalink }}"/>
     <link rel="stylesheet" href="{{ $home.RelPermalink }}"/>
     <link rel="stylesheet" href="{{ $about.RelPermalink }}"/>
     <link rel="stylesheet" href="{{ $reading.RelPermalink }}"/>
     <link rel="stylesheet" href="{{ $chat.RelPermalink }}"/>
     <link rel="stylesheet" href="{{ $chatPage.RelPermalink }}"/>
+    <link rel="stylesheet" href="{{ $krakow.RelPermalink }}"/>
     {{- $title := .Title | default .Site.Title -}}
     {{- $description := .Params.description | default .Site.Params.description -}}
     {{- $url := .Permalink -}}

--- a/layouts/krakow/recs/list.html
+++ b/layouts/krakow/recs/list.html
@@ -1,0 +1,162 @@
+{{ define "title" }}Krakow | {{ .Site.Title }}{{ end }}
+{{ define "main" }}
+  <div class="krakow-page" id="krakowPage">
+    <h1>Krakow</h1>
+    <p class="krakow-subtitle">A local's guide. Places I'd send friends to.</p>
+
+    {{ $allPages := .Pages }}
+
+    {{/* Extract unique categories */}}
+    {{ $categories := slice }}
+    {{ range $allPages }}
+      {{ with .Params.category }}
+        {{ $categories = $categories | append . }}
+      {{ end }}
+    {{ end }}
+    {{ $categories = $categories | uniq | sort }}
+
+    <div class="krakow-controls">
+      <div class="krakow-filters">
+        <button class="krakow-filter active" data-category="all">[all]</button>
+        {{ range $categories }}
+          <button class="krakow-filter" data-category="{{ . }}">[{{ . }}]</button>
+        {{ end }}
+        <span class="krakow-controls-sep">|</span>
+        <button class="krakow-kids-toggle" data-filter="kids">[with kids]</button>
+      </div>
+      <div class="krakow-right-controls">
+        <button class="krakow-view active" data-view="list">[list]</button>
+        <button class="krakow-view" data-view="cards">[cards]</button>
+      </div>
+    </div>
+
+    {{/* List view */}}
+    <div class="krakow-list" id="krakowList">
+      {{ range $allPages.ByTitle }}
+        <div class="krakow-entry" data-category="{{ .Params.category }}" data-kid="{{ if .Params.kid_friendly }}true{{ else }}false{{ end }}">
+          <div class="krakow-entry-info">
+            <a class="krakow-entry-title" href="{{ .RelPermalink }}">{{ .Title }}</a>
+            {{ with .Params.tagline }}
+              <span class="krakow-entry-tagline">{{ . }}</span>
+            {{ end }}
+          </div>
+          <div class="krakow-entry-meta">
+            {{ if .Params.kid_friendly }}<span class="krakow-tag-kid">kids</span>{{ end }}
+            <span class="krakow-tag">{{ .Params.category }}</span>
+          </div>
+        </div>
+      {{ end }}
+      <p class="krakow-empty" id="listEmpty">No places match this filter.</p>
+    </div>
+
+    {{/* Card view */}}
+    <div class="krakow-cards" id="krakowCards" style="display:none;">
+      {{ range $allPages.ByTitle }}
+        <a class="krakow-card" href="{{ .RelPermalink }}" data-category="{{ .Params.category }}" data-kid="{{ if .Params.kid_friendly }}true{{ else }}false{{ end }}">
+          {{ if .Params.photo }}
+            <div class="krakow-card-photo">
+              <img src="/images/krakow/{{ .Params.photo }}" alt="{{ .Title }}" loading="lazy">
+            </div>
+          {{ else }}
+            <div class="krakow-card-photo--placeholder" data-cat="{{ .Params.category }}">{{ .Params.category }}</div>
+          {{ end }}
+          <div class="krakow-card-body">
+            <span class="krakow-tag">{{ .Params.category }}</span>
+            {{ if .Params.kid_friendly }}<span class="krakow-tag-kid">kids</span>{{ end }}
+            <h3 class="krakow-card-title">{{ .Title }}</h3>
+            {{ with .Params.tagline }}
+              <p class="krakow-card-tagline">{{ . }}</p>
+            {{ end }}
+          </div>
+        </a>
+      {{ end }}
+      <p class="krakow-empty" id="cardsEmpty">No places match this filter.</p>
+    </div>
+  </div>
+
+  <script>
+  (function() {
+    var page = document.getElementById('krakowPage');
+    var listEl = document.getElementById('krakowList');
+    var cardsEl = document.getElementById('krakowCards');
+    var listEmpty = document.getElementById('listEmpty');
+    var cardsEmpty = document.getElementById('cardsEmpty');
+    var viewBtns = document.querySelectorAll('.krakow-view');
+    var filterBtns = document.querySelectorAll('.krakow-filter');
+    var kidsBtn = document.querySelector('.krakow-kids-toggle');
+    var entries = document.querySelectorAll('.krakow-entry');
+    var cards = document.querySelectorAll('.krakow-card');
+
+    var currentCategory = 'all';
+    var kidsOnly = false;
+
+    function applyFilters() {
+      var listVisible = 0;
+      var cardVisible = 0;
+
+      entries.forEach(function(el) {
+        var catMatch = currentCategory === 'all' || el.getAttribute('data-category') === currentCategory;
+        var kidMatch = !kidsOnly || el.getAttribute('data-kid') === 'true';
+        var show = catMatch && kidMatch;
+        el.classList.toggle('hidden', !show);
+        if (show) listVisible++;
+      });
+
+      cards.forEach(function(el) {
+        var catMatch = currentCategory === 'all' || el.getAttribute('data-category') === currentCategory;
+        var kidMatch = !kidsOnly || el.getAttribute('data-kid') === 'true';
+        var show = catMatch && kidMatch;
+        el.classList.toggle('hidden', !show);
+        if (show) cardVisible++;
+      });
+
+      listEmpty.classList.toggle('visible', listVisible === 0);
+      cardsEmpty.classList.toggle('visible', cardVisible === 0);
+    }
+
+    // View toggle
+    viewBtns.forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var view = this.getAttribute('data-view');
+        viewBtns.forEach(function(b) { b.classList.remove('active'); });
+        this.classList.add('active');
+
+        if (view === 'cards') {
+          listEl.style.display = 'none';
+          cardsEl.style.display = '';
+          page.classList.add('krakow-page--cards');
+        } else {
+          listEl.style.display = '';
+          cardsEl.style.display = 'none';
+          page.classList.remove('krakow-page--cards');
+        }
+
+        localStorage.setItem('krakow-view', view);
+      });
+    });
+
+    // Restore saved view
+    var savedView = localStorage.getItem('krakow-view');
+    if (savedView === 'cards') {
+      document.querySelector('.krakow-view[data-view="cards"]').click();
+    }
+
+    // Category filter
+    filterBtns.forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        currentCategory = this.getAttribute('data-category');
+        filterBtns.forEach(function(b) { b.classList.remove('active'); });
+        this.classList.add('active');
+        applyFilters();
+      });
+    });
+
+    // Kids toggle
+    kidsBtn.addEventListener('click', function() {
+      kidsOnly = !kidsOnly;
+      this.classList.toggle('active', kidsOnly);
+      applyFilters();
+    });
+  })();
+  </script>
+{{ end }}

--- a/layouts/krakow/recs/single.html
+++ b/layouts/krakow/recs/single.html
@@ -1,0 +1,53 @@
+{{ define "title" }}{{ .Title }} | Krakow | {{ .Site.Title }}{{ end }}
+{{ define "main" }}
+  <div class="content-wrapper krakow-single">
+    <article>
+      <p class="back-link"><a href="/krakow/recs/">&larr; Back to Krakow guide</a></p>
+
+      <h1>{{ .Title }}</h1>
+
+      <div class="krakow-detail-meta">
+        <span class="krakow-tag">{{ .Params.category }}</span>
+        {{ if .Params.kid_friendly }}<span class="krakow-tag-kid">kids</span>{{ end }}
+        {{ with .Params.address }}
+          <span class="krakow-address">
+            {{ with $.Params.map_url }}<a href="{{ . }}" target="_blank" rel="noopener">{{ end }}
+            {{ $.Params.address }}
+            {{ with $.Params.map_url }}</a>{{ end }}
+          </span>
+        {{ end }}
+      </div>
+
+      {{ with .Params.tagline }}
+        <p class="krakow-detail-tagline">{{ . }}</p>
+      {{ end }}
+
+      {{ if .Params.photo }}
+        <div class="krakow-detail-photo">
+          <img src="/images/krakow/{{ .Params.photo }}" alt="{{ .Title }}">
+        </div>
+      {{ else }}
+        <div class="krakow-detail-photo--placeholder" {{ with .Params.category }}data-cat="{{ . }}"{{ end }}>
+          {{ .Params.category }}
+        </div>
+      {{ end }}
+
+      <div class="krakow-detail-links">
+        {{ with .Params.map_url }}
+          <a href="{{ . }}" target="_blank" rel="noopener">View on map &rarr;</a>
+        {{ end }}
+        {{ with .Params.url }}
+          <a href="{{ . }}" target="_blank" rel="noopener">Website &rarr;</a>
+        {{ end }}
+      </div>
+
+      {{ with .Content }}
+        <div class="krakow-detail-content">
+          {{ . }}
+        </div>
+      {{ end }}
+
+      <p class="back-link"><a href="/krakow/recs/">&larr; Back to Krakow guide</a></p>
+    </article>
+  </div>
+{{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,6 +6,7 @@
       <li><a href="/now">Now</a></li>
       <li><a href="/reading/">Reading</a></li>
       <li><a href="/posts">Blog</a></li>
+      <li><a href="/krakow/recs/">Krakow</a></li>
       <li><button id="themeToggle" class="theme-toggle" aria-label="Toggle dark mode"></button></li>
     </ul>
   </nav>


### PR DESCRIPTION
## Summary

- Adds a shareable local's guide to Krakow at `/krakow/recs/` with 26 places seeded from Notion DB
- List and card view toggle (persisted in localStorage)
- Category filtering (auto-generated from content: coffee, food, museum, nature)
- Kid-friendly toggle (AND logic with category filter)
- Category-colored placeholder blocks for photos (to be added later)
- Full dark mode support, responsive down to mobile

## Test plan

- [ ] Visit `/krakow/recs/` - verify list view renders with all 26 entries
- [ ] Toggle to card view - verify 3-col grid with colored placeholders
- [ ] Filter by each category and verify correct entries shown
- [ ] Toggle "with kids" filter alone and combined with a category
- [ ] Click through to a detail page - verify back link, tagline, map link, category tag
- [ ] Toggle dark mode in both views
- [ ] Resize to mobile (600px) - cards go to 1 col, list entries stack
- [ ] Refresh page - verify view preference persists
- [ ] Check nav bar on mobile doesn't break with new "Krakow" link