### PR TITLE
fix(chat): include PostHog snippet on /chat/ page

### DIFF
--- a/layouts/_default/chat.html
+++ b/layouts/_default/chat.html
@@ -347,5 +347,6 @@
     </script>
     <script async defer src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
     <noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade" /></noscript>
+    {{ partial "posthog.html" . }}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- The `/chat/` page uses its own standalone layout (`layouts/_default/chat.html`) that bypasses `baseof.html`, so PostHog was never loaded there.
- Visits to `/chat/` — including real mobile users — were invisible in analytics.
- Simple Analytics was already present on the chat page; this brings PostHog to parity.

## User-facing impact
- Chat page visits now show up in PostHog alongside all other pages (e.g. top-pages queries will no longer silently exclude `/chat/`).
- No visible change to the chat UI on mobile or desktop — PostHog loads async, no DOM/CSS impact.

## Test plan
- [ ] Deploy to GitHub Pages (auto on merge to `main`).
- [ ] Visit `https://ostaps.net/chat/` and confirm a `$pageview` arrives in PostHog EU within ~1 min.
- [ ] Confirm chat functionality (send, clear, back, Turnstile) still works unchanged.