### PR TITLE
perf(home): inline critical CSS to cut LCP

### DIFF
--- a/assets/css/critical-base.css
+++ b/assets/css/critical-base.css
@@ -1,0 +1,218 @@
+/*
+ * Critical above-the-fold CSS, inlined in <head> on every page.
+ * Single source of truth for @font-face and theme variables -- these are
+ * NOT duplicated in styles.css. Keep this file small (renders inline).
+ */
+
+/* Self-hosted IBM Plex Mono (latin subset). Same-origin, swap to avoid blocking paint. */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('/fonts/ibm-plex-mono-400.woff2') format('woff2');
+}
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url('/fonts/ibm-plex-mono-700.woff2') format('woff2');
+}
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url('/fonts/ibm-plex-mono-400-italic.woff2') format('woff2');
+}
+
+/* Theme variables (single source of truth) */
+:root {
+  --primary-color: #111;
+  --secondary-color: #555;
+  --text-color: #333;
+  --background-color: #ededed;
+  --surface-color: transparent;
+  --border-color: #ccc;
+  --input-bg: #fff;
+  --max-content-width: 800px;
+  --font-family: 'IBM Plex Mono', 'Courier New', Courier, monospace;
+  --link-color: #0037ff;
+  --link-hover: #0024b3;
+  --accent-color: #0037ff;
+  --tag-fiction-border: #888;
+  --tag-fiction-color: #555;
+  --tag-nonfiction-border: #888;
+  --tag-nonfiction-color: #555;
+  --tag-reading-border: var(--accent-color);
+  --tag-reading-color: var(--accent-color);
+  --tag-toread-border: var(--accent-color);
+  --tag-toread-color: var(--accent-color);
+  --highlight-border: var(--accent-color);
+  --highlight-bg: #e4e4e4;
+}
+
+/* Dark mode - system preference */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --primary-color: #e8e8e8;
+    --secondary-color: #aaa;
+    --text-color: #d0d0d0;
+    --background-color: #1a1a1a;
+    --border-color: #444;
+    --input-bg: #2a2a2a;
+    --link-color: #5599ff;
+    --link-hover: #7bb3ff;
+    --accent-color: #3366cc;
+    --highlight-bg: #2a2a2a;
+    --tag-fiction-border: #777;
+    --tag-fiction-color: #aaa;
+    --tag-nonfiction-border: #777;
+    --tag-nonfiction-color: #aaa;
+  }
+}
+
+/* Dark mode - manual override */
+:root[data-theme="dark"] {
+  --primary-color: #e8e8e8;
+  --secondary-color: #aaa;
+  --text-color: #d0d0d0;
+  --background-color: #1a1a1a;
+  --border-color: #444;
+  --input-bg: #2a2a2a;
+  --link-color: #5599ff;
+  --link-hover: #7bb3ff;
+  --accent-color: #3366cc;
+  --highlight-bg: #2a2a2a;
+  --tag-fiction-border: #777;
+  --tag-fiction-color: #aaa;
+  --tag-nonfiction-border: #777;
+  --tag-nonfiction-color: #aaa;
+}
+
+/* Above-the-fold base: reset, body type, headings, links, header/nav. */
+* {
+  box-sizing: border-box;
+}
+
+body, html {
+  margin: 0;
+  width: 100%;
+  overflow-x: hidden;
+  font-family: var(--font-family);
+  font-size: 0.95rem;
+  line-height: 1.55;
+  background-color: var(--background-color);
+  color: var(--primary-color);
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 900;
+  margin: 0 0 0.5rem;
+  color: var(--primary-color);
+}
+
+h2 {
+  font-size: 1.4rem;
+  font-weight: 900;
+  margin: 2rem 0 0.5rem;
+  color: var(--primary-color);
+}
+
+a {
+  color: var(--link-color);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+a:hover {
+  color: var(--link-hover);
+}
+
+main {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+header {
+  width: 100%;
+  background-color: var(--surface-color);
+  padding: 1.2rem 2.5rem;
+  margin-bottom: 0;
+}
+
+nav ul {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  justify-content: flex-end;
+}
+
+nav ul li {
+  margin: 0 0 0 1.8rem;
+}
+
+nav ul li.nav-home {
+  margin-right: auto;
+  margin-left: 0;
+}
+
+nav ul li a {
+  color: var(--primary-color);
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+nav ul li a:hover {
+  color: var(--link-color);
+}
+
+.theme-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-family);
+  font-size: 0.82rem;
+  font-weight: 400;
+  color: var(--secondary-color);
+  text-decoration: none;
+  padding: 0;
+  letter-spacing: 0.02em;
+}
+
+.theme-toggle:hover {
+  color: var(--primary-color);
+}
+
+@media (max-width: 600px) {
+  h1 { font-size: 1.6rem; }
+  h2 { font-size: 1.1rem; }
+
+  nav ul {
+    gap: 0;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  nav ul li {
+    margin: 0.25rem 0.5rem;
+  }
+
+  header {
+    padding: 1rem 1rem;
+  }
+}

--- a/assets/css/critical-home.css
+++ b/assets/css/critical-home.css
@@ -1,0 +1,58 @@
+/*
+ * Critical above-the-fold CSS for the homepage, inlined in <head>.
+ * Covers the greeting (LCP element) and the 3-column info grid only.
+ * Below-the-fold rules (.home-building, .home-bottom, etc.) stay in
+ * home-styles.css. Duplicated here with home-styles.css -- keep in sync.
+ */
+
+.home {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 40px 40px 0;
+}
+
+.home-greeting {
+  text-align: center;
+  font-size: 2.2rem;
+  letter-spacing: -0.02em;
+  margin: 0 0 2rem;
+}
+
+.home-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.home-col h2 {
+  font-size: 1rem;
+  margin: 0 0 0.5rem;
+}
+
+.home-col ul {
+  list-style: none;
+  padding: 0 0 0 0.75rem;
+  margin: 0;
+}
+
+.home-col ul li {
+  margin-bottom: 0.2rem;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 600px) {
+  .home {
+    padding: 30px 16px 24px;
+  }
+
+  .home-greeting {
+    font-size: 1.6rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .home-grid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+}

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,91 +1,9 @@
-/* Self-hosted IBM Plex Mono (latin subset). Same-origin, swap to avoid blocking paint. */
-@font-face {
-  font-family: 'IBM Plex Mono';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url('/fonts/ibm-plex-mono-400.woff2') format('woff2');
-}
-
-@font-face {
-  font-family: 'IBM Plex Mono';
-  font-style: normal;
-  font-weight: 700;
-  font-display: swap;
-  src: url('/fonts/ibm-plex-mono-700.woff2') format('woff2');
-}
-
-@font-face {
-  font-family: 'IBM Plex Mono';
-  font-style: italic;
-  font-weight: 400;
-  font-display: swap;
-  src: url('/fonts/ibm-plex-mono-400-italic.woff2') format('woff2');
-}
-
-/* CSS Variables */
-:root {
-  --primary-color: #111;
-  --secondary-color: #555;
-  --text-color: #333;
-  --background-color: #ededed;
-  --surface-color: transparent;
-  --border-color: #ccc;
-  --input-bg: #fff;
-  --max-content-width: 800px;
-  --font-family: 'IBM Plex Mono', 'Courier New', Courier, monospace;
-  --link-color: #0037ff;
-  --link-hover: #0024b3;
-  --accent-color: #0037ff;
-  --tag-fiction-border: #888;
-  --tag-fiction-color: #555;
-  --tag-nonfiction-border: #888;
-  --tag-nonfiction-color: #555;
-  --tag-reading-border: var(--accent-color);
-  --tag-reading-color: var(--accent-color);
-  --tag-toread-border: var(--accent-color);
-  --tag-toread-color: var(--accent-color);
-  --highlight-border: var(--accent-color);
-  --highlight-bg: #e4e4e4;
-}
-
-/* Dark mode - system preference */
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    --primary-color: #e8e8e8;
-    --secondary-color: #aaa;
-    --text-color: #d0d0d0;
-    --background-color: #1a1a1a;
-    --border-color: #444;
-    --input-bg: #2a2a2a;
-    --link-color: #5599ff;
-    --link-hover: #7bb3ff;
-    --accent-color: #3366cc;
-    --highlight-bg: #2a2a2a;
-    --tag-fiction-border: #777;
-    --tag-fiction-color: #aaa;
-    --tag-nonfiction-border: #777;
-    --tag-nonfiction-color: #aaa;
-  }
-}
-
-/* Dark mode - manual override */
-:root[data-theme="dark"] {
-  --primary-color: #e8e8e8;
-  --secondary-color: #aaa;
-  --text-color: #d0d0d0;
-  --background-color: #1a1a1a;
-  --border-color: #444;
-  --input-bg: #2a2a2a;
-  --link-color: #5599ff;
-  --link-hover: #7bb3ff;
-  --accent-color: #3366cc;
-  --highlight-bg: #2a2a2a;
-  --tag-fiction-border: #777;
-  --tag-fiction-color: #aaa;
-  --tag-nonfiction-border: #777;
-  --tag-nonfiction-color: #aaa;
-}
+/*
+ * @font-face and theme variables (:root, dark mode) live in
+ * critical-base.css, which is inlined in <head> as the single source of
+ * truth. They are intentionally NOT repeated here. Base typography below
+ * is mirrored in critical-base.css for first paint -- keep the two in sync.
+ */
 
 /* Reset and Base Styles */
 * {

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,6 +6,8 @@
     <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
     <link rel="preload" as="font" type="font/woff2" href="/fonts/ibm-plex-mono-700.woff2" crossorigin>
     <link rel="preload" as="font" type="font/woff2" href="/fonts/ibm-plex-mono-400.woff2" crossorigin>
+    {{/* Critical above-the-fold CSS inlined to unblock first paint (fonts + theme vars + base). */}}
+    {{ partial "inline-css.html" "css/critical-base.css" }}
     {{/* Global stylesheets: base styles + the floating chat widget (rendered on every baseof page). */}}
     {{ partial "css.html" "css/styles.css" }}
     {{ partial "css.html" "css/chat-styles.css" }}

--- a/layouts/_default/chat.html
+++ b/layouts/_default/chat.html
@@ -6,6 +6,7 @@
     <title>Chat with Ostap</title>
     <link rel="preload" as="font" type="font/woff2" href="/fonts/ibm-plex-mono-700.woff2" crossorigin>
     <link rel="preload" as="font" type="font/woff2" href="/fonts/ibm-plex-mono-400.woff2" crossorigin>
+    {{ partial "inline-css.html" "css/critical-base.css" }}
     {{ partial "css.html" "css/styles.css" }}
     {{ partial "css.html" "css/chat-page-styles.css" }}
     <link rel="icon" type="image/png" href="/favicon.png">

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -1,5 +1,5 @@
 {{ define "title" }}Ostap Senyuk{{ end }}
-{{ define "css" }}{{ partial "css.html" "css/home-styles.css" }}{{ end }}
+{{ define "css" }}{{ partial "inline-css.html" "css/critical-home.css" }}{{ partial "css.html" "css/home-styles.css" }}{{ end }}
 {{ define "main" }}
   <div class="home">
     <h1 class="home-greeting">HI, I'M OSTAP</h1>

--- a/layouts/partials/inline-css.html
+++ b/layouts/partials/inline-css.html
@@ -1,0 +1,3 @@
+{{- /* Inlines a stylesheet as a <style> block. Context is a path relative to assets/, e.g. "css/critical-base.css". Used for critical above-the-fold CSS to avoid a render-blocking round trip. */ -}}
+{{- $r := resources.Get . | minify -}}
+<style>{{ $r.Content | safeCSS }}</style>


### PR DESCRIPTION
## Why

Round 1 (#6) took the homepage from **64 → 78** on Lighthouse mobile and made TBT/SI/CLS green, but **LCP stayed red at 5.2s** — the only metric blocking 90+. The ~3s gap between FCP (2.2s) and LCP was the font-load chain: the `@font-face` rule lived inside render-blocking `styles.css`, so the browser couldn't swap the bold heading to IBM Plex Mono until that CSS round trip completed, even with the woff2 preloaded.

## What changed

Inline the critical above-the-fold CSS in `<head>` so first and largest paint need zero CSS round trips:

- **`critical-base.css`** (fonts + theme vars + base typography + header) — inlined on **every page** via a new `layouts/partials/inline-css.html`. This is now the **single source of truth** for `@font-face` and the `:root` / dark-mode variables, removed from `styles.css` so they can't drift.
- **`critical-home.css`** (the greeting + 3-column grid) — inlined **only on the homepage**, where the bold `HI, I'M OSTAP` heading is the LCP element.

The full stylesheets still load normally (render-blocking) for below-the-fold content — per the design review, async-loading them was not worth the FOUC/CLS risk on a payload this small. Theme vars are inlined alongside the existing synchronous theme script, so there's no dark-mode flash.

## User-facing impact

Visitors on slow mobile connections see the styled heading paint without waiting for an external stylesheet round trip. No visual change intended.

## Verification done

- `hugo --gc --minify` builds clean.
- Head order correct: font preloads → inline `<style>` (critical-base) → stylesheet links → inline `<style>` (critical-home, homepage only).
- Inline blocks contain `@font-face` + `:root` + h1 typography; `styles.css` output no longer contains them (dedup confirmed).
- Chat page gets critical-base inline and stays lean (no `.home-*`); base-only pages (now/colophon) get critical-base too.
- Inline `<style>` is well-formed and minified; pages + fonts serve 200.

## Reviewer notes

- **Re-run Lighthouse mobile** to confirm LCP drops under 2.5s and score hits 90+.
- Drift guard: `@font-face` and theme vars are single-sourced in `critical-base.css`. The base typography + `.home-*` rules are mirrored between the critical files and the full sheets — small and visually obvious if they diverge, but worth a glance when editing those rules.
- CI pins Hugo 0.159.2 (local 0.162.1) — watch the first deploy run.